### PR TITLE
set a default value for the errcontext parameter to support php 8.0+

### DIFF
--- a/lib/GLogger.php
+++ b/lib/GLogger.php
@@ -253,7 +253,7 @@ class GLogger {
 	 * @param int    $errline
 	 * @param mixed  $errcontext
 	 */
-	public static function ErrorHandler($errno, $errstr, $errfile, $errline, $errcontext) {
+	public static function ErrorHandler($errno, $errstr, $errfile, $errline, $errcontext = []) {
 		// this is from Z-Push but might be helpful in the future: https://wiki.z-hub.io/x/sIEa
 		if (defined('LOG_ERROR_MASK')) {
 			$errno &= LOG_ERROR_MASK;


### PR DESCRIPTION
The errcontext parameter has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0.
If the function defines this parameter without a default, an error of "too few arguments" will be raised when it is called.